### PR TITLE
fix: restrict construction_order when searching for node callbacks

### DIFF
--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Collection, Sequence
 import logging
 
 from .architecture_exporter import ArchitectureExporter
-from .architecture_loaded import NodeValuesLoaded
+from .architecture_loaded import NodeValuesLoaded, MAX_CONSTRUCTION_ORDER
 from .combine_path import CombinePath
 
 from .reader_interface import ArchitectureReader, IGNORE_TOPICS
@@ -35,8 +35,6 @@ from ..value_objects import (CallbackGroupStructValue, CallbackStructValue,
 from ..value_objects.node import DiffNode
 
 logger = logging.getLogger(__name__)
-
-MAX_CONSTRUCTION_ORDER = 10
 
 class Architecture(Summarizable):
     def __init__(

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -36,12 +36,14 @@ from ..value_objects.node import DiffNode
 
 logger = logging.getLogger(__name__)
 
+MAX_CONSTRUCTION_ORDER = 10
 
 class Architecture(Summarizable):
     def __init__(
         self,
         file_type: str,
         file_path: str,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded
@@ -51,7 +53,7 @@ class Architecture(Summarizable):
 
         reader = ArchitectureReaderFactory.create_instance(
             file_type, file_path)
-        loaded = ArchitectureLoaded(reader, ignore_topics)
+        loaded = ArchitectureLoaded(reader, ignore_topics, max_construction_order=max_construction_order)
 
         self._nodes: list[NodeStruct] = loaded.nodes
         self._communications: list[CommunicationStruct] = loaded.communications

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Collection, Sequence
 import logging
 
 from .architecture_exporter import ArchitectureExporter
-from .architecture_loaded import NodeValuesLoaded, MAX_CONSTRUCTION_ORDER
+from .architecture_loaded import MAX_CONSTRUCTION_ORDER, NodeValuesLoaded
 from .combine_path import CombinePath
 
 from .reader_interface import ArchitectureReader, IGNORE_TOPICS
@@ -36,6 +36,7 @@ from ..value_objects.node import DiffNode
 
 logger = logging.getLogger(__name__)
 
+
 class Architecture(Summarizable):
     def __init__(
         self,
@@ -43,9 +44,6 @@ class Architecture(Summarizable):
         file_path: str,
         max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
-        if max_construction_order == 0:
-            max_construction_order = MAX_CONSTRUCTION_ORDER
-
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded
 
@@ -54,7 +52,9 @@ class Architecture(Summarizable):
 
         reader = ArchitectureReaderFactory.create_instance(
             file_type, file_path)
-        loaded = ArchitectureLoaded(reader, ignore_topics, max_construction_order=max_construction_order)
+        loaded = ArchitectureLoaded(reader,
+                                    ignore_topics,
+                                    max_construction_order=max_construction_order)
 
         self._nodes: list[NodeStruct] = loaded.nodes
         self._communications: list[CommunicationStruct] = loaded.communications

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -43,6 +43,9 @@ class Architecture(Summarizable):
         file_path: str,
         max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
+        if max_construction_order == 0:
+            max_construction_order = MAX_CONSTRUCTION_ORDER
+
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded
 

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -1615,12 +1615,6 @@ class CallbackPathSearched():
                 if max_construction_order != 0:
                     if write_callback.construction_order > max_construction_order or \
                         read_callback.construction_order > max_construction_order:
-                            """
-                            if node.node_name not in skip_nodes:
-                                skip_nodes.append(node.node_name)
-                                logger.warn(f'skip due to callback construction_order over'
-                                            f'({max_construction_order}): {node.node_name}')
-                            """
                             skip_nodes.append(node.node_name)
                             continue
                 searched_paths = searcher.search(write_callback, read_callback, node)

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -57,18 +57,20 @@ def indexed_name(base_name: str, i: int, num_digit: int):
     index_str = str(i).zfill(num_digit)
     return f'{base_name}_{index_str}'
 
+MAX_CONSTRUCTION_ORDER = 10
 
 class ArchitectureLoaded():
     def __init__(
         self,
         reader: ArchitectureReader,
-        ignore_topics: list[str]
+        ignore_topics: list[str],
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
 
         topic_ignored_reader = TopicIgnoredReader(reader, ignore_topics)
 
         self._nodes: list[NodeStruct]
-        nodes_loaded = NodeValuesLoaded(topic_ignored_reader)
+        nodes_loaded = NodeValuesLoaded(topic_ignored_reader, max_construction_order=max_construction_order)
 
         self._nodes = nodes_loaded.data
 
@@ -274,6 +276,7 @@ class NodeValuesLoaded():
     def __init__(
         self,
         reader: ArchitectureReader,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
         self._reader = reader
         nodes_struct: list[NodeStruct] = []
@@ -291,7 +294,7 @@ class NodeValuesLoaded():
 
         for node in Progress.tqdm(nodes, 'Loading nodes.'):
             try:
-                node, cb_loaded, cbg_loaded = self._create_node(node, reader)
+                node, cb_loaded, cbg_loaded = self._create_node(node, reader, max_construction_order=max_construction_order)
                 nodes_struct.append(node)
                 self._cb_loaded.append(cb_loaded)
                 self._cbg_loaded.append(cbg_loaded)
@@ -446,6 +449,7 @@ class NodeValuesLoaded():
     def _create_node(
         node: NodeValue,
         reader: ArchitectureReader,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> tuple[NodeStruct, CallbacksLoaded, CallbackGroupsLoaded]:
 
         callbacks_loaded = CallbacksLoaded(reader, node)
@@ -476,7 +480,7 @@ class NodeValuesLoaded():
         )
 
         try:
-            node_paths = NodeValuesLoaded._search_node_paths(node_struct, reader)
+            node_paths = NodeValuesLoaded._search_node_paths(node_struct, reader, max_construction_order=max_construction_order)
             node_path_added = NodeStruct(
                 node_struct.node_name, node_struct.publishers,
                 node_struct.subscriptions,
@@ -496,14 +500,15 @@ class NodeValuesLoaded():
     @staticmethod
     def _search_node_paths(
         node: NodeStruct,
-        reader: ArchitectureReader
+        reader: ArchitectureReader,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> list[NodePathStruct]:
 
         node_paths: list[NodePathStruct] = []
 
         # add callback-graph paths
         logger.info('[callback_chain]')
-        node_paths += list(CallbackPathSearched(node).data)
+        node_paths += list(CallbackPathSearched(node, max_construction_order).data)
 
         # add pub-sub pair graph paths
         logger.info('\n[pub-sub pair]')
@@ -1588,6 +1593,7 @@ class CallbackPathSearched():
     def __init__(
         self,
         node: NodeStruct,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
         from .graph_search import CallbackPathSearcher
         self._data: list[NodePathStruct]
@@ -1599,6 +1605,10 @@ class CallbackPathSearched():
 
         if callbacks is not None:
             for write_callback, read_callback in product(callbacks, callbacks):
+                if max_construction_order != 0:
+                    if write_callback.construction_order > max_construction_order or \
+                       read_callback.construction_order > max_construction_order:
+                           continue
                 searched_paths = searcher.search(write_callback, read_callback, node)
                 for path in searched_paths:
                     msg = 'Path Added: '

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -1615,10 +1615,13 @@ class CallbackPathSearched():
                 if max_construction_order != 0:
                     if write_callback.construction_order > max_construction_order or \
                         read_callback.construction_order > max_construction_order:
+                            """
                             if node.node_name not in skip_nodes:
                                 skip_nodes.append(node.node_name)
                                 logger.warn(f'skip due to callback construction_order over'
                                             f'({max_construction_order}): {node.node_name}')
+                            """
+                            skip_nodes.append(node.node_name)
                             continue
                 searched_paths = searcher.search(write_callback, read_callback, node)
                 for path in searched_paths:
@@ -1628,6 +1631,12 @@ class CallbackPathSearched():
                     msg += f'callbacks: {path.callback_names}'
                     logger.info(msg)
                 paths += searched_paths
+
+            from collections import Counter
+            skip_node_counts = Counter(skip_nodes)
+            for name, count in skip_node_counts.items():
+                logger.warn(f'skip due to callback construction_order over'
+                            f'({max_construction_order}): {name} ({count})')
 
         self._data = paths
 

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -54,6 +54,7 @@ logger = getLogger(__name__)
 
 MAX_CONSTRUCTION_ORDER = 10
 
+
 def indexed_name(base_name: str, i: int, num_digit: int):
     index_str = str(i).zfill(num_digit)
     return f'{base_name}_{index_str}'
@@ -70,7 +71,7 @@ class ArchitectureLoaded():
         topic_ignored_reader = TopicIgnoredReader(reader, ignore_topics)
 
         self._nodes: list[NodeStruct]
-        nodes_loaded = NodeValuesLoaded(topic_ignored_reader, 
+        nodes_loaded = NodeValuesLoaded(topic_ignored_reader,
                                         max_construction_order=max_construction_order)
 
         self._nodes = nodes_loaded.data
@@ -295,9 +296,11 @@ class NodeValuesLoaded():
 
         for node in Progress.tqdm(nodes, 'Loading nodes.'):
             try:
-                node, cb_loaded, cbg_loaded = self._create_node(node, 
-                                                                reader, 
-                                                                max_construction_order=max_construction_order)
+                node, cb_loaded, cbg_loaded = self._create_node(
+                    node,
+                    reader,
+                    max_construction_order=max_construction_order
+                )
                 nodes_struct.append(node)
                 self._cb_loaded.append(cb_loaded)
                 self._cbg_loaded.append(cbg_loaded)
@@ -484,9 +487,11 @@ class NodeValuesLoaded():
 
         try:
             node_paths = \
-                    NodeValuesLoaded._search_node_paths(node_struct, 
-                                                        reader, 
-                                                        max_construction_order=max_construction_order)
+                    NodeValuesLoaded._search_node_paths(
+                        node_struct,
+                        reader,
+                        max_construction_order=max_construction_order
+                    )
             node_path_added = NodeStruct(
                 node_struct.node_name, node_struct.publishers,
                 node_struct.subscriptions,
@@ -1614,9 +1619,9 @@ class CallbackPathSearched():
             for write_callback, read_callback in product(callbacks, callbacks):
                 if max_construction_order != 0:
                     if write_callback.construction_order > max_construction_order or \
-                        read_callback.construction_order > max_construction_order:
-                            skip_nodes.append(node.node_name)
-                            continue
+                            read_callback.construction_order > max_construction_order:
+                        skip_nodes.append(node.node_name)
+                        continue
                 searched_paths = searcher.search(write_callback, read_callback, node)
                 for path in searched_paths:
                     msg = 'Path Added: '

--- a/src/test/architecture/test_architecture.py
+++ b/src/test/architecture/test_architecture.py
@@ -21,7 +21,7 @@ from logging import WARNING
 from string import Template
 
 from caret_analyze.architecture import Architecture
-from caret_analyze.architecture.architecture_loaded import ArchitectureLoaded, MAX_CONSTRUCTION_ORDER
+from caret_analyze.architecture.architecture_loaded import ArchitectureLoaded
 from caret_analyze.architecture.architecture_reader_factory import \
     ArchitectureReaderFactory
 from caret_analyze.architecture.graph_search import NodePathSearcher
@@ -131,13 +131,11 @@ def create_arch(mocker):
 def create_node(
     create_publisher: Callable[[str, str], PublisherStructValue],
     create_subscription: Callable[[str, str], SubscriptionStructValue],
-    max_construction_order: int = MAX_CONSTRUCTION_ORDER
 ):
     def _create_node(
         node_name: str,
         sub_topic_name: str | None,
         pub_topic_name: str | None,
-        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> NodeStructValue:
         pubs: tuple[PublisherStructValue, ...]
         subs: tuple[SubscriptionStructValue, ...]

--- a/src/test/architecture/test_architecture.py
+++ b/src/test/architecture/test_architecture.py
@@ -21,7 +21,7 @@ from logging import WARNING
 from string import Template
 
 from caret_analyze.architecture import Architecture
-from caret_analyze.architecture.architecture_loaded import ArchitectureLoaded
+from caret_analyze.architecture.architecture_loaded import ArchitectureLoaded, MAX_CONSTRUCTION_ORDER
 from caret_analyze.architecture.architecture_reader_factory import \
     ArchitectureReaderFactory
 from caret_analyze.architecture.graph_search import NodePathSearcher
@@ -130,12 +130,14 @@ def create_arch(mocker):
 @pytest.fixture
 def create_node(
     create_publisher: Callable[[str, str], PublisherStructValue],
-    create_subscription: Callable[[str, str], SubscriptionStructValue]
+    create_subscription: Callable[[str, str], SubscriptionStructValue],
+    max_construction_order: int = MAX_CONSTRUCTION_ORDER
 ):
     def _create_node(
         node_name: str,
         sub_topic_name: str | None,
-        pub_topic_name: str | None
+        pub_topic_name: str | None,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> NodeStructValue:
         pubs: tuple[PublisherStructValue, ...]
         subs: tuple[SubscriptionStructValue, ...]

--- a/src/test/architecture/test_architecture_loader.py
+++ b/src/test/architecture/test_architecture_loader.py
@@ -18,6 +18,7 @@ from caret_analyze.architecture.architecture_loaded import (ArchitectureLoaded,
                                                             CallbacksLoaded,
                                                             CommValuesLoaded,
                                                             ExecutorValuesLoaded,
+                                                            MAX_CONSTRUCTION_ORDER,
                                                             NodePathCreated,
                                                             NodeValuesLoaded,
                                                             PathValuesLoaded,
@@ -237,7 +238,11 @@ class TestNodesInfoLoaded():
         mocker.patch.object(
             reader_mock, 'get_nodes', return_value=[node_b, node_c, node_a])
 
-        def create_node(node, reader):
+        def create_node(
+            node,
+            reader,
+            max_construction_order: int = MAX_CONSTRUCTION_ORDER
+        ):
             node_mock = mocker.Mock(spec=NodeStruct)
             cb_loaded_mock = mocker.Mock(spec=CallbacksLoaded)
             cbg_loaded_mock = mocker.Mock(spec=CallbackGroupsLoaded)
@@ -713,6 +718,7 @@ class TestNodePathLoaded:
 
     def test_full(self, mocker):
         searcher_mock = mocker.Mock(spec=CallbackPathSearcher)
+        searcher_mock.max_construction_order = MAX_CONSTRUCTION_ORDER
         mocker.patch('caret_analyze.architecture.graph_search.CallbackPathSearcher',
                      return_value=searcher_mock)
 

--- a/src/test/architecture/test_architecture_loader.py
+++ b/src/test/architecture/test_architecture_loader.py
@@ -718,11 +718,11 @@ class TestNodePathLoaded:
 
     def test_full(self, mocker):
         searcher_mock = mocker.Mock(spec=CallbackPathSearcher)
-        searcher_mock.max_construction_order = MAX_CONSTRUCTION_ORDER
         mocker.patch('caret_analyze.architecture.graph_search.CallbackPathSearcher',
                      return_value=searcher_mock)
 
         callback_mock = mocker.Mock(spec=CallbackStruct)
+        callback_mock.construction_order = MAX_CONSTRUCTION_ORDER - 1
         node_path_mock = mocker.Mock(NodePathStruct)
         mocker.patch.object(searcher_mock, 'search',
                             return_value=[node_path_mock])
@@ -732,7 +732,7 @@ class TestNodePathLoaded:
         callbacks = (callback_mock, callback_mock)
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(node_mock, 'callbacks', callbacks)
-        searched = CallbackPathSearched(node_mock)
+        searched = CallbackPathSearched(node_mock, MAX_CONSTRUCTION_ORDER)
 
         import itertools
         product = list(itertools.product(callbacks, callbacks))


### PR DESCRIPTION
## Description

restrict construction_order when searching for node callbacks

## Related links

[https://tier4.atlassian.net/browse/RT2-1261](https://tier4.atlassian.net/browse/RT2-1261)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
